### PR TITLE
Update to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "author": "Nathan Friedly - http://nfriedly.com/",
   "license": "MIT",
   "dependencies": {
-    "archiver": "^0.12.0",
+    "archiver": "^0.21.0",
     "async": "^0.9.0",
     "concat-stream": "^1.4.6",
     "yargs": "^1.3.2"


### PR DESCRIPTION
There was an issue in the archiver module fixed in v0.15.1, which can cause file permissions issues on windows:
https://github.com/archiverjs/node-archiver/issues/136
https://github.com/archiverjs/node-archiver/pull/137