### PR TITLE
Excludes the destination zip file

### DIFF
--- a/lib/bestzip.js
+++ b/lib/bestzip.js
@@ -61,7 +61,7 @@ function nodeZip(dest, sources, done) {
             }
             if (stats.isDirectory()) {
                 archive.bulk([
-                    {expand: true, cwd: source, src: ['**'], dot: true, dest: zipDest}
+                    {expand: true, cwd: source, src: ['**', '!' + dest], dot: true, dest: zipDest}
                 ]);
             } else if (stats.isFile()) {
                 archive.file(source, {name: basename, stats: stats});

--- a/lib/bestzip.js
+++ b/lib/bestzip.js
@@ -60,8 +60,13 @@ function nodeZip(dest, sources, done) {
                 return next(err);
             }
             if (stats.isDirectory()) {
+                var matches = ['**'];
+                // exclude zip file being created
+                if (pathUtil.resolve() == pathUtil.resolve(source)) {
+                    matches.push('!' + dest);
+                }
                 archive.bulk([
-                    {expand: true, cwd: source, src: ['**', '!' + dest], dot: true, dest: zipDest}
+                    {expand: true, cwd: source, src: matches, dot: true, dest: zipDest}
                 ]);
             } else if (stats.isFile()) {
                 archive.file(source, {name: basename, stats: stats});


### PR DESCRIPTION
When doing the archiver bulk creation of the zip file, the destination zip file is included within the zip file being created (multiple times).  This will exclude the destination zip file being included in the final zip file being created, but will still allow any zip files in sub directories that happen to have the same name as the destination zip file to still be created.
e.g. if my destination zip is my-new-zip.zip, then /my-new-zip.zip will be excluded but /my/sub/directory/my-new-zip.zip will still be added.