### PR TITLE
Follow symlink directories when zipping

### DIFF
--- a/lib/bestzip.js
+++ b/lib/bestzip.js
@@ -60,7 +60,7 @@ function nodeZip(dest, sources, done) {
                 return next(err);
             }
             if (stats.isDirectory()) {
-                var matches = ['**'];
+                var matches = ['**/**'];
                 // exclude zip file being created
                 if (pathUtil.resolve() == pathUtil.resolve(source)) {
                     matches.push('!' + dest);


### PR DESCRIPTION
I found that symlinks did not appear to be followed when zipping directories on Windows using the nodeZip method.
By expanding the pattern in "matches", it now appears to follow those links to the underlying directories and subdirectories.

My current directory structure was e.g. ./node_modules/linked_folder/node_modules/(many other folders here).  Prior to the change it would just insert the "symlinked folders" as "symlinks" in the zip file.  This change will now add the actual folders that were symlinked to (which I *think* makes more sense than how it previously functioned).

This has only been validated on a windows machine, so if anyone is on a mac and can test using symlinked folders, please feel free to give that a try.

This also allows us to maintain the v0.21.0 archiver rather than upgrading to the latest, which would have many breaking changes.