### PR TITLE
Command line option to include dependencies specified in the package.json 

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -5,39 +5,39 @@
 var zip = require("../lib/bestzip.js");
 
 var argv = require("yargs")
-    .usage("\nUsage: bestzip destination.zip sources/")
-    .option("force", {
-        describe: "Force use of node.js or native zip methods",
-        choices: ["node", "native"]
-    })
-    .option('dependencies', {
-        alias: 'd',
-        describe: "Includes dependencies from a package.json file",
-    })
-    .demand(2).argv;
+  .usage("\nUsage: bestzip destination.zip sources/")
+  .option("force", {
+    describe: "Force use of node.js or native zip methods",
+    choices: ["node", "native"]
+  })
+  .option("dependencies", {
+    alias: "d",
+    describe: "Includes dependencies from a package.json file"
+  })
+  .demand(2).argv;
 
 const destination = argv._.shift();
 const source = argv._;
-const packageFile = (argv.d === true) ? 'package.json' : argv.d;
+const packageFile = argv.d === true ? "package.json" : argv.d;
 
 console.log("Writing %s to %s...", source.join(", "), destination);
 
 if (argv.force === "node") {
-    zip = zip.nodeZip;
+  zip = zip.nodeZip;
 } else if (argv.force === "native") {
-    zip = zip.nativeZip;
+  zip = zip.nativeZip;
 }
 
 zip({
-        source: source,
-        destination: destination,
-        verbose: argv.verbose,
-        packageFile: packageFile
-    })
-    .then(function() {
-        console.log("zipped!");
-    })
-    .catch(function(err) {
-        console.error(err);
-        process.exit(1);
-    });
+  source: source,
+  destination: destination,
+  verbose: argv.verbose,
+  packageFile: packageFile
+})
+  .then(function() {
+    console.log("zipped!");
+  })
+  .catch(function(err) {
+    console.error(err);
+    process.exit(1);
+  });

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -5,33 +5,39 @@
 var zip = require("../lib/bestzip.js");
 
 var argv = require("yargs")
-  .usage("\nUsage: bestzip destination.zip sources/")
-  .option("force", {
-    describe: "Force use of node.js or native zip methods",
-    choices: ["node", "native"]
-  })
-  .demand(2).argv;
+    .usage("\nUsage: bestzip destination.zip sources/")
+    .option("force", {
+        describe: "Force use of node.js or native zip methods",
+        choices: ["node", "native"]
+    })
+    .option('dependencies', {
+        alias: 'd',
+        describe: "Includes dependencies from a package.json file",
+    })
+    .demand(2).argv;
 
-var destination = argv._.shift();
-var source = argv._;
+const destination = argv._.shift();
+const source = argv._;
+const packageFile = (argv.d === true) ? 'package.json' : argv.d;
 
 console.log("Writing %s to %s...", source.join(", "), destination);
 
 if (argv.force === "node") {
-  zip = zip.nodeZip;
+    zip = zip.nodeZip;
 } else if (argv.force === "native") {
-  zip = zip.nativeZip;
+    zip = zip.nativeZip;
 }
 
 zip({
-  source: source,
-  destination: destination,
-  verbose: argv.verbose
-})
-  .then(function() {
-    console.log("zipped!");
-  })
-  .catch(function(err) {
-    console.error(err);
-    process.exit(1);
-  });
+        source: source,
+        destination: destination,
+        verbose: argv.verbose,
+        packageFile: packageFile
+    })
+    .then(function() {
+        console.log("zipped!");
+    })
+    .catch(function(err) {
+        console.error(err);
+        process.exit(1);
+    });

--- a/lib/bestzip.js
+++ b/lib/bestzip.js
@@ -14,163 +14,167 @@ const glob = require("glob");
 let _hasNativeZip = null;
 
 function hasNativeZip() {
-    if (_hasNativeZip === null) {
-        try {
-            cp.execSync("zip -?");
-            _hasNativeZip = true;
-        } catch (err) {
-            _hasNativeZip = false;
-        }
+  if (_hasNativeZip === null) {
+    try {
+      cp.execSync("zip -?");
+      _hasNativeZip = true;
+    } catch (err) {
+      _hasNativeZip = false;
     }
+  }
 
-    return _hasNativeZip;
+  return _hasNativeZip;
 }
 
-const getPackageInfo = (packageFile) =>
-    new Promise((resolve, reject) => {
-        fs.readFile(packageFile, 'utf-8', (err, data) => {
-            if (err) {
-                console.error(`\n\t${err}\n`);
-                reject(err)
-            } else {
-                resolve(JSON.parse(data))
-            }
-        })
-    })
+const getPackageInfo = packageFile =>
+  new Promise((resolve, reject) => {
+    fs.readFile(packageFile, "utf-8", (err, data) => {
+      if (err) {
+        // console.error(`\n\t${err}\n`);
+        reject(err);
+      } else {
+        resolve(JSON.parse(data));
+      }
+    });
+  });
 
-const getDependencies = (packageFile) =>
-    new Promise((resolve, reject) => {
-        const cwd = process.cwd();
-        const pkg = path.resolve(cwd, packageFile);
-        const rootDir = path.relative(cwd, path.dirname(pkg));
+const getDependencies = packageFile =>
+  new Promise(resolve => {
+    const cwd = process.cwd();
+    const pkg = path.resolve(cwd, packageFile);
+    const rootDir = path.relative(cwd, path.dirname(pkg));
 
-        let includePatterns = getPackageInfo(pkg)
-            .then(rootPackage => {
-                const dependencies = Object.keys(rootPackage.dependencies || {})
-                    .map(x => `${rootDir}/node_modules/${x}/**`)
-                resolve(dependencies)
-            })
-    })
+    getPackageInfo(pkg).then(rootPackage => {
+      const dependencies = Object.keys(rootPackage.dependencies || {}).map(
+        x => `${rootDir}/node_modules/${x}/**`
+      );
+      resolve(dependencies);
+    });
+  });
 
 const nativeZip = options =>
-    new Promise((resolve, reject) => {
-        const sources = Array.isArray(options.source) ?
-            options.source.join(" ") :
-            options.source;
+  new Promise((resolve, reject) => {
+    const sources = Array.isArray(options.source)
+      ? options.source.join(" ")
+      : options.source;
 
-        const command = `zip --quiet --recurse-paths ${options.destination} ${sources}`;
-        const zipProcess = cp.exec(command, {
-            stdio: "inherit",
-            cwd: options.cwd
-        });
-        zipProcess.on("error", reject);
-        zipProcess.on("close", exitCode => {
-            if (exitCode === 0) {
-                resolve();
-            } else {
-                // exit code 12 means "nothing to do" right?
-                //console.log('rejecting', zipProcess)
-                reject(
-                    new Error(
-                        `Unexpected exit code from native zip command: ${exitCode}\n executed command '${command}'\n executed inin directory '${options.cwd ||
-                  process.cwd()}'`
-                    )
-                );
-            }
-        });
+    const command = `zip --quiet --recurse-paths ${
+      options.destination
+    } ${sources}`;
+    const zipProcess = cp.exec(command, {
+      stdio: "inherit",
+      cwd: options.cwd
     });
+    zipProcess.on("error", reject);
+    zipProcess.on("close", exitCode => {
+      if (exitCode === 0) {
+        resolve();
+      } else {
+        // exit code 12 means "nothing to do" right?
+        //console.log('rejecting', zipProcess)
+        reject(
+          new Error(
+            `Unexpected exit code from native zip command: ${exitCode}\n executed command '${command}'\n executed inin directory '${options.cwd ||
+              process.cwd()}'`
+          )
+        );
+      }
+    });
+  });
 
 // based on http://stackoverflow.com/questions/15641243/need-to-zip-an-entire-directory-using-node-js/18775083#18775083
 const nodeZip = options =>
-    new Promise((resolve, reject) => {
-        const cwd = options.cwd || process.cwd();
-        const output = fs.createWriteStream(path.resolve(cwd, options.destination));
-        const archive = archiver("zip");
+  new Promise((resolve, reject) => {
+    const cwd = options.cwd || process.cwd();
+    const output = fs.createWriteStream(path.resolve(cwd, options.destination));
+    const archive = archiver("zip");
 
-        output.on("close", resolve);
-        archive.on("error", reject);
+    output.on("close", resolve);
+    archive.on("error", reject);
 
-        archive.pipe(output);
+    archive.pipe(output);
 
-        const globOpts = {
-            cwd: cwd,
-            // options to behave more like the native zip's glob support
-            dot: false, // ignore .dotfiles
-            noglobstar: true, // treat ** as *
-            noext: true, // no (a|b)
-            nobrace: true // no {a,b}
-        };
+    const globOpts = {
+      cwd: cwd,
+      // options to behave more like the native zip's glob support
+      dot: false, // ignore .dotfiles
+      noglobstar: true, // treat ** as *
+      noext: true, // no (a|b)
+      nobrace: true // no {a,b}
+    };
 
-        function findSource(source, next) {
-            if (glob.hasMagic(source, globOpts)) {
-                // archiver uses this library but somehow ends up with different results on windows:
-                // archiver.glob('*') will include subdirectories, but omit their contents on windows
-                // so we'll use glob directly, and add all of the files it finds
-                glob(source, globOpts, function(err, files) {
-                    if (err) {
-                        return next(err);
-                    }
-                    async.forEach(files, addSource, next);
-                });
-            } else {
-                addSource(source, next);
-            }
-        }
-
-        function addSource(source, next) {
-            const fullPath = path.resolve(cwd, source);
-            const destPath = source;
-            fs.stat(fullPath, function(err, stats) {
-                if (err) {
-                    return next(err);
-                }
-                if (stats.isDirectory()) {
-                    archive.directory(fullPath, destPath);
-                } else if (stats.isFile()) {
-                    archive.file(fullPath, { stats: stats, name: destPath });
-                }
-                next();
-            });
-        }
-
-        const sources = Array.isArray(options.source) ?
-            options.source : [options.source];
-
-        async.forEach(sources, findSource, function(err) {
-            if (err) {
-                return reject(err);
-            }
-            archive.finalize();
+    function findSource(source, next) {
+      if (glob.hasMagic(source, globOpts)) {
+        // archiver uses this library but somehow ends up with different results on windows:
+        // archiver.glob('*') will include subdirectories, but omit their contents on windows
+        // so we'll use glob directly, and add all of the files it finds
+        glob(source, globOpts, function(err, files) {
+          if (err) {
+            return next(err);
+          }
+          async.forEach(files, addSource, next);
         });
+      } else {
+        addSource(source, next);
+      }
+    }
+
+    function addSource(source, next) {
+      const fullPath = path.resolve(cwd, source);
+      const destPath = source;
+      fs.stat(fullPath, function(err, stats) {
+        if (err) {
+          return next(err);
+        }
+        if (stats.isDirectory()) {
+          archive.directory(fullPath, destPath);
+        } else if (stats.isFile()) {
+          archive.file(fullPath, { stats: stats, name: destPath });
+        }
+        next();
+      });
+    }
+
+    const sources = Array.isArray(options.source)
+      ? options.source
+      : [options.source];
+
+    async.forEach(sources, findSource, function(err) {
+      if (err) {
+        return reject(err);
+      }
+      archive.finalize();
     });
+  });
 
 function execZip(options) {
-    const compatMode = typeof options === "string";
-    if (compatMode) {
-        options = {
-            source: arguments[1],
-            destination: arguments[0],
-        };
-    }
+  const compatMode = typeof options === "string";
+  if (compatMode) {
+    options = {
+      source: arguments[1],
+      destination: arguments[0]
+    };
+  }
 
-    let promise = hasNativeZip() ? nativeZip(options) : promise = nodeZip(options);
-    if (compatMode) {
-        promise.then(arguments[2]).catch(arguments[2]);
-    } else {
-        return promise;
-    }
+  let promise = hasNativeZip()
+    ? nativeZip(options)
+    : (promise = nodeZip(options));
+  if (compatMode) {
+    promise.then(arguments[2]).catch(arguments[2]);
+  } else {
+    return promise;
+  }
 }
 
 function zip(options) {
-    if (options.packageFile) {
-        return getDependencies(options.packageFile)
-            .then((dependencies) => {
-                options.source = options.source.concat(dependencies)
-                return execZip(options);
-            })
-    } else {
-        return execZip(options);
-    }
+  if (options.packageFile) {
+    return getDependencies(options.packageFile).then(dependencies => {
+      options.source = options.source.concat(dependencies);
+      return execZip(options);
+    });
+  } else {
+    return execZip(options);
+  }
 }
 
 module.exports = zip;

--- a/lib/bestzip.js
+++ b/lib/bestzip.js
@@ -14,133 +14,163 @@ const glob = require("glob");
 let _hasNativeZip = null;
 
 function hasNativeZip() {
-  if (_hasNativeZip === null) {
-    try {
-      cp.execSync("zip -?");
-      _hasNativeZip = true;
-    } catch (err) {
-      _hasNativeZip = false;
+    if (_hasNativeZip === null) {
+        try {
+            cp.execSync("zip -?");
+            _hasNativeZip = true;
+        } catch (err) {
+            _hasNativeZip = false;
+        }
     }
-  }
 
-  return _hasNativeZip;
+    return _hasNativeZip;
 }
 
+const getPackageInfo = (packageFile) =>
+    new Promise((resolve, reject) => {
+        fs.readFile(packageFile, 'utf-8', (err, data) => {
+            if (err) {
+                console.error(`\n\t${err}\n`);
+                reject(err)
+            } else {
+                resolve(JSON.parse(data))
+            }
+        })
+    })
+
+const getDependencies = (packageFile) =>
+    new Promise((resolve, reject) => {
+        const cwd = process.cwd();
+        const pkg = path.resolve(cwd, packageFile);
+        const rootDir = path.relative(cwd, path.dirname(pkg));
+
+        let includePatterns = getPackageInfo(pkg)
+            .then(rootPackage => {
+                const dependencies = Object.keys(rootPackage.dependencies || {})
+                    .map(x => `${rootDir}/node_modules/${x}/**`)
+                resolve(dependencies)
+            })
+    })
+
 const nativeZip = options =>
-  new Promise((resolve, reject) => {
-    const sources = Array.isArray(options.source)
-      ? options.source.join(" ")
-      : options.source;
-    const command = `zip --quiet --recurse-paths ${
-      options.destination
-    } ${sources}`;
-    const zipProcess = cp.exec(command, {
-      stdio: "inherit",
-      cwd: options.cwd
+    new Promise((resolve, reject) => {
+        const sources = Array.isArray(options.source) ?
+            options.source.join(" ") :
+            options.source;
+
+        const command = `zip --quiet --recurse-paths ${options.destination} ${sources}`;
+        const zipProcess = cp.exec(command, {
+            stdio: "inherit",
+            cwd: options.cwd
+        });
+        zipProcess.on("error", reject);
+        zipProcess.on("close", exitCode => {
+            if (exitCode === 0) {
+                resolve();
+            } else {
+                // exit code 12 means "nothing to do" right?
+                //console.log('rejecting', zipProcess)
+                reject(
+                    new Error(
+                        `Unexpected exit code from native zip command: ${exitCode}\n executed command '${command}'\n executed inin directory '${options.cwd ||
+                  process.cwd()}'`
+                    )
+                );
+            }
+        });
     });
-    zipProcess.on("error", reject);
-    zipProcess.on("close", exitCode => {
-      if (exitCode === 0) {
-        resolve();
-      } else {
-        // exit code 12 means "nothing to do" right?
-        //console.log('rejecting', zipProcess)
-        reject(
-          new Error(
-            `Unexpected exit code from native zip command: ${exitCode}\n executed command '${command}'\n executed inin directory '${options.cwd ||
-              process.cwd()}'`
-          )
-        );
-      }
-    });
-  });
 
 // based on http://stackoverflow.com/questions/15641243/need-to-zip-an-entire-directory-using-node-js/18775083#18775083
 const nodeZip = options =>
-  new Promise((resolve, reject) => {
-    const cwd = options.cwd || process.cwd();
-    const output = fs.createWriteStream(path.resolve(cwd, options.destination));
-    const archive = archiver("zip");
+    new Promise((resolve, reject) => {
+        const cwd = options.cwd || process.cwd();
+        const output = fs.createWriteStream(path.resolve(cwd, options.destination));
+        const archive = archiver("zip");
 
-    output.on("close", resolve);
-    archive.on("error", reject);
+        output.on("close", resolve);
+        archive.on("error", reject);
 
-    archive.pipe(output);
+        archive.pipe(output);
 
-    const globOpts = {
-      cwd: cwd,
-      // options to behave more like the native zip's glob support
-      dot: false, // ignore .dotfiles
-      noglobstar: true, // treat ** as *
-      noext: true, // no (a|b)
-      nobrace: true // no {a,b}
-    };
+        const globOpts = {
+            cwd: cwd,
+            // options to behave more like the native zip's glob support
+            dot: false, // ignore .dotfiles
+            noglobstar: true, // treat ** as *
+            noext: true, // no (a|b)
+            nobrace: true // no {a,b}
+        };
 
-    function findSource(source, next) {
-      if (glob.hasMagic(source, globOpts)) {
-        // archiver uses this library but somehow ends up with different results on windows:
-        // archiver.glob('*') will include subdirectories, but omit their contents on windows
-        // so we'll use glob directly, and add all of the files it finds
-        glob(source, globOpts, function(err, files) {
-          if (err) {
-            return next(err);
-          }
-          async.forEach(files, addSource, next);
+        function findSource(source, next) {
+            if (glob.hasMagic(source, globOpts)) {
+                // archiver uses this library but somehow ends up with different results on windows:
+                // archiver.glob('*') will include subdirectories, but omit their contents on windows
+                // so we'll use glob directly, and add all of the files it finds
+                glob(source, globOpts, function(err, files) {
+                    if (err) {
+                        return next(err);
+                    }
+                    async.forEach(files, addSource, next);
+                });
+            } else {
+                addSource(source, next);
+            }
+        }
+
+        function addSource(source, next) {
+            const fullPath = path.resolve(cwd, source);
+            const destPath = source;
+            fs.stat(fullPath, function(err, stats) {
+                if (err) {
+                    return next(err);
+                }
+                if (stats.isDirectory()) {
+                    archive.directory(fullPath, destPath);
+                } else if (stats.isFile()) {
+                    archive.file(fullPath, { stats: stats, name: destPath });
+                }
+                next();
+            });
+        }
+
+        const sources = Array.isArray(options.source) ?
+            options.source : [options.source];
+
+        async.forEach(sources, findSource, function(err) {
+            if (err) {
+                return reject(err);
+            }
+            archive.finalize();
         });
-      } else {
-        addSource(source, next);
-      }
-    }
-
-    function addSource(source, next) {
-      const fullPath = path.resolve(cwd, source);
-      const destPath = source;
-      fs.stat(fullPath, function(err, stats) {
-        if (err) {
-          return next(err);
-        }
-        if (stats.isDirectory()) {
-          archive.directory(fullPath, destPath);
-        } else if (stats.isFile()) {
-          archive.file(fullPath, { stats: stats, name: destPath });
-        }
-        next();
-      });
-    }
-
-    const sources = Array.isArray(options.source)
-      ? options.source
-      : [options.source];
-
-    async.forEach(sources, findSource, function(err) {
-      if (err) {
-        return reject(err);
-      }
-      archive.finalize();
     });
-  });
+
+function execZip(options) {
+    const compatMode = typeof options === "string";
+    if (compatMode) {
+        options = {
+            source: arguments[1],
+            destination: arguments[0],
+        };
+    }
+
+    let promise = hasNativeZip() ? nativeZip(options) : promise = nodeZip(options);
+    if (compatMode) {
+        promise.then(arguments[2]).catch(arguments[2]);
+    } else {
+        return promise;
+    }
+}
 
 function zip(options) {
-  const compatMode = typeof options === "string";
-  if (compatMode) {
-    options = {
-      source: arguments[1],
-      destination: arguments[0]
-    };
-  }
-
-  let promise;
-  if (hasNativeZip()) {
-    promise = nativeZip(options);
-  } else {
-    promise = nodeZip(options);
-  }
-
-  if (compatMode) {
-    promise.then(arguments[2]).catch(arguments[2]);
-  } else {
-    return promise;
-  }
+    if (options.packageFile) {
+        return getDependencies(options.packageFile)
+            .then((dependencies) => {
+                options.source = options.source.concat(dependencies)
+                return execZip(options);
+            })
+    } else {
+        return execZip(options);
+    }
 }
 
 module.exports = zip;

--- a/package-lock.json
+++ b/package-lock.json
@@ -4336,9 +4336,9 @@
       }
     },
     "merge": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
-      "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
+      "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
       "dev": true
     },
     "merge-stream": {

--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ The `--recurse-directories` (`-r`) option is automatically enabled.
 ## Global command line usage
 
     npm install -g bestzip
-    bestzip destination.zip source/ [other sources...]
+    bestzip destination.zip source/ [other sources...] [--dependencies package.json]
 
 ## Command line usage within `package.json` scripts
 
@@ -75,6 +75,21 @@ Alternatively:
 This will not include the build/ folder, it's contents will be top-level.
 
 When using the programmatic API, the same effect may be achieved by passing in the `cwd` option.
+
+## Include dependencies
+
+When you need to include your `package.json` dependencies from `node_modules`, you can use the `--dependencies` option to specify the location of your `package.json` file:
+
+`bestzip build.zip build/* --dependencies`
+
+will include all the modules listed inside "dependencies" in your `./package.json` file.
+
+Alternatively you can specify the relative path:
+
+`cd build/ && bestzip ../build.zip * -d ../package.json`
+
+
+
 
 ## .dotfiles
 


### PR DESCRIPTION
First of all thanks, this tool is really useful!

To automate an AWS lambda deployment I needed a programmatic way to create an archive containing all the runtime files needed to execute this function. There are some npm packages that can do this but are less configurable ([pack-zip](https://www.npmjs.com/package/pack-zip), [npm-pack-zip](https://www.npmjs.com/package/npm-pack-zip))

## Include dependencies
 When you need to include your `package.json` dependencies from `node_modules`, you can use the `--dependencies` option to specify the location of your `package.json` file:

`bestzip build.zip build/* --dependencies`

 will include all the modules listed inside "dependencies" in your `./package.json` file.

 Alternatively you can specify the relative path:

`cd build/ && bestzip ../build.zip * -d ../package.json`