### PR TITLE
Ignore stderr message if no native zip

### DIFF
--- a/lib/bestzip.js
+++ b/lib/bestzip.js
@@ -10,20 +10,10 @@ const path = require("path");
 const archiver = require("archiver");
 const async = require("async");
 const glob = require("glob");
-
-let _hasNativeZip = null;
+const which = require("which");
 
 function hasNativeZip() {
-  if (_hasNativeZip === null) {
-    try {
-      cp.execSync("zip -?");
-      _hasNativeZip = true;
-    } catch (err) {
-      _hasNativeZip = false;
-    }
-  }
-
-  return _hasNativeZip;
+  return Boolean(which.sync("zip", {nothrow: true}));
 }
 
 const nativeZip = options =>

--- a/lib/bestzip.js
+++ b/lib/bestzip.js
@@ -13,7 +13,7 @@ const glob = require("glob");
 const which = require("which");
 
 function hasNativeZip() {
-  return Boolean(which.sync("zip", {nothrow: true}));
+  return Boolean(which.sync("zip", { nothrow: true }));
 }
 
 const nativeZip = options =>

--- a/package-lock.json
+++ b/package-lock.json
@@ -2231,7 +2231,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2252,12 +2253,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2272,17 +2275,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2399,7 +2405,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2411,6 +2418,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2425,6 +2433,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2432,12 +2441,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2456,6 +2467,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2536,7 +2548,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2548,6 +2561,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2633,7 +2647,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2669,6 +2684,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2688,6 +2704,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2731,12 +2748,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "archiver": "^3.0.0",
     "async": "^2.6.1",
     "glob": "^7.1.3",
+    "which": "^1.3.1",
     "yargs": "^13.2.4"
   },
   "devDependencies": {


### PR DESCRIPTION
This will prevent stderr from showing confusing zip not recognized message:
!["no zip found message"](https://user-images.githubusercontent.com/10860657/64568259-87595d00-d317-11e9-9f4e-fed7dec1f2b3.png)

on windows when bestzip is still working, but will use node zip instead.