### PR TITLE
chore: remove unused regenerator-runtime dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,12 +26,11 @@
         "jest": "^29.7.0",
         "klaw-sync": "^6.0.0",
         "prettier": "^2.2.1",
-        "regenerator-runtime": "^0.13.7",
         "rimraf": "^3.0.2",
         "unzip-stream": "^0.3.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=20"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -5466,12 +5465,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/regenerator-runtime": {
-      "version": "0.13.7",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
-      "dev": true
-    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -10181,12 +10174,6 @@
           }
         }
       }
-    },
-    "regenerator-runtime": {
-      "version": "0.13.7",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
-      "dev": true
     },
     "require-directory": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "jest": "^29.7.0",
     "klaw-sync": "^6.0.0",
     "prettier": "^2.2.1",
-    "regenerator-runtime": "^0.13.7",
     "rimraf": "^3.0.2",
     "unzip-stream": "^0.3.1"
   }


### PR DESCRIPTION
The `regenerator-runtime` dev dependency does not seem to be used anywhere