### PR TITLE
fix: ensure input files can't be treated as command line flags

### DIFF
--- a/lib/bestzip.js
+++ b/lib/bestzip.js
@@ -63,7 +63,7 @@ const nativeZip = async (options) => {
   const command = "zip";
   const sources = await expandSources(cwd, options.source);
 
-  const args = ["--quiet", "--recurse-paths", options.destination].concat(
+  const args = ["--quiet", "--recurse-paths", options.destination, "--"].concat(
     sources
   );
   if (

--- a/test/command_injection.test.js
+++ b/test/command_injection.test.js
@@ -53,6 +53,12 @@ describe("command injection", () => {
       source: ["file.txt", "obama.jpg; mkdir -p injection"],
       destination: destination,
     },
+    {
+      cwd: "test/fixtures",
+      // -T validates the created .zip, and -TT provides the command for zip to use when unzipping for validation
+      source: ["file.txt", "-T", "-TT", "mkdir -p injection"],
+      destination: destination,
+    },
   ];
 
   for (const testCase of testCases) {


### PR DESCRIPTION
This is annoying if a file name begins with "-", but it's a vlunerability if the native zip command supports the `--test` & `--unzip-command` (`-T` & `-TT`) flags, because it will execute whatever command comes next.

Thanks @poqpwppy for the report