### PR TITLE
Fix: prevent native zip destination from being interpereted as a flag

### DIFF
--- a/lib/bestzip.js
+++ b/lib/bestzip.js
@@ -63,6 +63,12 @@ const nativeZip = async (options) => {
   const command = "zip";
   const sources = await expandSources(cwd, options.source);
 
+  if (options.destination?.[0] === "-") {
+    throw new Error(
+      "Bestzip: destination for native zip command must not begin with - (dash) because it would be interpreted as an argument"
+    );
+  }
+
   const args = ["--quiet", "--recurse-paths", options.destination, "--"].concat(
     sources
   );

--- a/lib/bestzip.js
+++ b/lib/bestzip.js
@@ -62,14 +62,9 @@ const nativeZip = async (options) => {
   const cwd = options.cwd || process.cwd();
   const command = "zip";
   const sources = await expandSources(cwd, options.source);
+  const destination = path.resolve(cwd, options.destination);
 
-  if (options.destination?.[0] === "-") {
-    throw new Error(
-      "Bestzip: destination for native zip command must not begin with - (dash) because it would be interpreted as an argument"
-    );
-  }
-
-  const args = ["--quiet", "--recurse-paths", options.destination, "--"].concat(
+  const args = ["--quiet", "--recurse-paths", destination, "--"].concat(
     sources
   );
   if (

--- a/test/command_injection.test.js
+++ b/test/command_injection.test.js
@@ -1,73 +1,42 @@
 import { describe, test, beforeEach, after } from "node:test";
 import fs from "node:fs";
+import path from "node:path";
 import * as bestzip from "../lib/bestzip.js";
 import { init } from "./helpers.js";
-
-const { destination, cleanup } = init("command_injection");
 
 describe("command injection", () => {
   const hasNativeZip = bestzip.hasNativeZip();
 
-  beforeEach(cleanup);
+  const { destination, fixturesDir: cwd, reset, cleanup } = init(
+    "command_injection",
+    true // copy the fixtures to the tempdir; fixturesDir will point to the copy
+  );
+
+  beforeEach(reset);
   after(cleanup);
 
-  // https://www.npmjs.com/advisories/1554
   const testCases = [
+    // note: cwd and destination will get included automatically unless overridden in the test case
     {
-      cwd: "test/fixtures",
       source: "file.txt",
       destination: destination + "; mkdir -p injection",
     },
+    { source: "file.txt; mkdir -p injection" },
+    { source: ["file.txt;", " mkdir -p injection"] },
+    { source: ["file.txt", "; mkdir -p injection"] },
+    { source: ["file.txt;", ";mkdir -p injection"] },
+    { source: ["file.txt", "mkdir -p injection"] },
+    { source: ["file.txt; mkdir -p injection"] },
+    { source: ["file.txt", "obama.jpg; mkdir -p injection"] },
     {
-      cwd: "test/fixtures",
-      source: "file.txt; mkdir -p injection",
-      destination: destination,
-    },
-    {
-      cwd: "test/fixtures",
-      source: ["file.txt;", " mkdir -p injection"],
-      destination: destination,
-    },
-    {
-      cwd: "test/fixtures",
-      source: ["file.txt", "; mkdir -p injection"],
-      destination: destination,
-    },
-    {
-      cwd: "test/fixtures",
-      source: ["file.txt;", ";mkdir -p injection"],
-      destination: destination,
-    },
-    {
-      cwd: "test/fixtures",
-      source: ["file.txt", "mkdir -p injection"],
-      destination: destination,
-    },
-    {
-      cwd: "test/fixtures",
-      source: ["file.txt; mkdir -p injection"],
-      destination: destination,
-    },
-    {
-      cwd: "test/fixtures",
-      source: ["file.txt", "obama.jpg; mkdir -p injection"],
-      destination: destination,
-    },
-    {
-      cwd: "test/fixtures",
       // --test validates the created .zip, and --unzip-command provides the command for zip to execute when unzipping for validation
       source: ["file.txt", "--test", "--unzip-command", "mkdir -p injection"],
-      destination: destination,
     },
     {
-      cwd: "test/fixtures",
       // -T and -TT are aliases for --test and --unzip-command
       source: ["file.txt", "-T", "-TT", "mkdir -p injection"],
-      destination: destination,
     },
     {
-      cwd: "test/fixtures",
-      // if destination is interpreted as a flag that takes an argument, it will eat the -- that prevents sources from being interpreted as arguments
       source: [
         "fakedest.zip",
         "file.txt",
@@ -75,7 +44,29 @@ describe("command injection", () => {
         "--unzip-command",
         "mkdir -p injection",
       ],
+      // if destination is interpreted as a flag that takes an argument, it will eat the -- that prevents sources from being interpreted as arguments
       destination: "-n",
+    },
+    // variations of the above targeted at windows. I haven't actually seen these fail, but I figure the tests won't hurt
+    {
+      source: [
+        "fakedest.zip",
+        "file.txt",
+        "--test",
+        "--unzip-command",
+        "mkdir -p injection",
+      ],
+      destination: "\\x",
+    },
+    {
+      source: [
+        "fakedest.zip",
+        "file.txt",
+        "--test",
+        "--unzip-command",
+        "mkdir -p injection",
+      ],
+      destination: "/x",
     },
   ];
 
@@ -86,15 +77,16 @@ describe("command injection", () => {
       )}`,
       { skip: !hasNativeZip },
       async () => {
+        const args = { cwd, destination, ...testCase };
         try {
-          await bestzip.zip(testCase);
+          await bestzip.zip(args);
         } catch (ex) {
-          // Exceptions are allowed, that is invalid input.
+          // Exceptions are allowed, we gave it invalid input.
           // The important part is that it doesn't execute it.
           // Some test cases will log "zip error: Nothing to do!" or similar - that is to be expected
         }
 
-        if (fs.existsSync("test/fixtures/injection")) {
+        if (fs.existsSync(path.join(args.cwd, "injection"))) {
           throw new Error(
             "Bestzip appears to be vulnerable to command injection"
           );

--- a/test/command_injection.test.js
+++ b/test/command_injection.test.js
@@ -65,6 +65,18 @@ describe("command injection", () => {
       source: ["file.txt", "-T", "-TT", "mkdir -p injection"],
       destination: destination,
     },
+    {
+      cwd: "test/fixtures",
+      // if destination is interpreted as a flag that takes an argument, it will eat the -- that prevents sources from being interpreted as arguments
+      source: [
+        "fakedest.zip",
+        "file.txt",
+        "--test",
+        "--unzip-command",
+        "mkdir -p injection",
+      ],
+      destination: "-n",
+    },
   ];
 
   for (const testCase of testCases) {

--- a/test/file_structure.test.js
+++ b/test/file_structure.test.js
@@ -6,7 +6,7 @@ import { describe, test, before, beforeEach, after } from "node:test";
 import klaw from "klaw-sync";
 import { init } from "./helpers.js";
 
-const { tmpdir, destination, cleanup } = init("file_structure");
+const { tmpdir, destination, reset, cleanup } = init("file_structure");
 const __dirname = import.meta.dirname;
 
 import unzip from "./unzip.js";
@@ -60,7 +60,7 @@ describe("file structure", () => {
   const hasNativeZip = bestzip.hasNativeZip();
 
   before(createSymlink);
-  beforeEach(cleanup);
+  beforeEach(reset);
   after(cleanup);
 
   // these tests have known good snapshots
@@ -182,7 +182,7 @@ describe("file structure", () => {
         await unzip(destination, tmpdir);
         const nodeStructure = getStructure(tmpdir);
 
-        await cleanup();
+        await reset();
 
         child_process.execSync(
           `node ${cli} --force=native ${destination} ${args}`

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,18 +1,26 @@
 import path from "node:path";
-import fs from "node:fs";
 import fsp from "node:fs/promises";
 import os from "node:os";
 
-const init = (name) => {
-  const tmpdir = path.join(os.tmpdir(), "bestzip", name); // path.join(__dirname, "tmp");
-  fs.mkdirSync(tmpdir, { recursive: true });
+const init = (name, copyFixtures = false) => {
+  const tmpdir = path.join(os.tmpdir(), `bestzip_${name}`);
   const destination = path.join(tmpdir, "test.zip");
+  const fixturesDir = copyFixtures
+    ? path.join(tmpdir, "fixtures")
+    : "test/fixtures";
+
   const cleanup = async () => {
     await fsp.rm(tmpdir, { recursive: true, force: true });
-    await fsp.mkdir(tmpdir, { recursive: true });
-    await fsp.rm("test/fixtures/injection", { recursive: true, force: true });
   };
-  return { tmpdir, destination, cleanup };
+
+  const reset = async () => {
+    await cleanup();
+    await fsp.mkdir(tmpdir, { recursive: true });
+    if (copyFixtures) {
+      await fsp.cp("test/fixtures", fixturesDir, { recursive: true });
+    }
+  };
+  return { tmpdir, fixturesDir, destination, reset, cleanup };
 };
 
 export { init };

--- a/test/perf.test.js
+++ b/test/perf.test.js
@@ -4,10 +4,10 @@ import { describe, test, beforeEach, after } from "node:test";
 import { init } from "./helpers.js";
 import * as bestzip from "../lib/bestzip.js";
 
-const { destination, cleanup } = init("perf");
+const { destination, reset, cleanup } = init("perf");
 
 describe("Performance", () => {
-  beforeEach(cleanup);
+  beforeEach(reset);
   after(cleanup);
 
   const getPerf = async (zipFn) => {


### PR DESCRIPTION
Fixes an issue reported by @iamabighotdog that was overlooked in https://github.com/nfriedly/node-bestzip/pull/97.

(Unfortunately the native zip command requires the destination to come before the `--`, otherwise this fix could be simpler and more reliable.)