### PR TITLE
fix: Make nodeZip default symlink behavior match native zip

### DIFF
--- a/lib/bestzip.js
+++ b/lib/bestzip.js
@@ -155,11 +155,9 @@ const nativeZip = async (options) => {
 // based on http://stackoverflow.com/questions/15641243/need-to-zip-an-entire-directory-using-node-js/18775083#18775083
 const nodeZip = async (options) => {
   const cwd = options.cwd || process.cwd();
-  // followSymLinks: false stores symlinks as links. The default (unset)
-  // preserves master's existing behavior unchanged; followSymLinks: true
-  // explicitly follows symlinks.
+  // followSymLinks: false stores symlinks as links; the default (unset or
+  // true) follows symlinks, matching the native zip implementation.
   const storeLinks = options.followSymLinks === false;
-  const follow = options.followSymLinks === true;
   const output = fs.createWriteStream(path.resolve(cwd, options.destination));
   const archive = new ZipArchive({
     zlib: { level: options.level },
@@ -237,19 +235,15 @@ const nodeZip = async (options) => {
       const files = walkDir(fullPath);
       for (const f of files) {
         const subPath = f.substring(fullPath.length);
-        if (follow) {
-          // Pass explicit (stat) stats so archiver dereferences symlinks and
-          // stores their target contents rather than the link itself.
-          archive.file(f, {
-            name: destPath + subPath,
-            stats: fs.statSync(f),
-          });
-        } else {
-          // Default (unset): preserve master behavior exactly.
-          archive.file(f, {
-            name: destPath + subPath,
-          });
-        }
+        // Pass explicit (stat) stats so archiver dereferences symlinks and
+        // stores their target contents rather than the link itself. This makes
+        // the default behavior match the native zip implementation, which
+        // follows symlinks (only followSymLinks: false opts into storing them
+        // as links via the storeLinks branch above).
+        archive.file(f, {
+          name: destPath + subPath,
+          stats: fs.statSync(f),
+        });
       }
     } else if (stats.isFile()) {
       archive.file(fullPath, { stats: stats, name: destPath });

--- a/test/symlink_default_behavior.test.js
+++ b/test/symlink_default_behavior.test.js
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { after, beforeEach, describe, test } from "node:test";
+
+import * as bestzip from "../lib/bestzip.js";
+import { canCreateSymlinks, init, readZipEntries } from "./helpers.js";
+
+const S_IFREG = 0o100000;
+
+const { tmpdir } = init("symlink_default_behavior");
+const cwd = path.join(tmpdir, "cwd");
+const targetFile = path.join(cwd, "target.txt");
+const vendorDir = path.join(cwd, "vendor");
+const archiveDir = path.join(cwd, "archive-me");
+const linkToFile = path.join(archiveDir, "link.txt");
+const linkToDir = path.join(archiveDir, "vendor");
+const topLink = path.join(cwd, "top-link.txt");
+const topDirLink = path.join(cwd, "vendor-link");
+const destination = path.join(cwd, "out.zip");
+
+const TARGET_CONTENTS = "the target file contents";
+
+const setup = () => {
+  fs.mkdirSync(archiveDir, { recursive: true });
+  fs.mkdirSync(vendorDir, { recursive: true });
+  fs.writeFileSync(targetFile, TARGET_CONTENTS);
+  fs.writeFileSync(path.join(vendorDir, "vendored.txt"), "from vendor dir");
+  try {
+    fs.symlinkSync(targetFile, topLink);
+  } catch (e) {
+    // already exists
+  }
+  try {
+    fs.symlinkSync(vendorDir, topDirLink, "dir");
+  } catch (e) {
+    // already exists
+  }
+  try {
+    fs.symlinkSync(targetFile, linkToFile);
+  } catch (e) {
+    // already exists
+  }
+  try {
+    fs.symlinkSync(vendorDir, linkToDir, "dir");
+  } catch (e) {
+    // already exists
+  }
+};
+
+// The default (unset) nodeZip behavior must match the native zip
+// implementation: symlinks are followed, so their target contents are
+// archived and symlinked directories are recursed into. These tests lock in
+// that parity, so nodeZip and nativeZip agree when followSymLinks is unset.
+describe(
+  "default (unset) nodeZip symlink behavior",
+  { skip: !canCreateSymlinks() },
+  () => {
+    beforeEach(() => {
+      fs.rmSync(tmpdir, { recursive: true, force: true });
+      fs.mkdirSync(cwd, { recursive: true });
+      setup();
+    });
+    after(() => fs.rmSync(tmpdir, { recursive: true, force: true }));
+
+    test("follows a file symlink inside a walked directory", async () => {
+      await bestzip.nodeZip({ cwd, source: "archive-me/", destination });
+      const entries = readZipEntries(destination);
+      assert.equal(entries["archive-me/link.txt"].type, S_IFREG);
+      assert.equal(
+        entries["archive-me/link.txt"].data.toString(),
+        TARGET_CONTENTS
+      );
+      assert.ok(entries["archive-me/vendor/vendored.txt"]);
+    });
+
+    test("follows a top-level symlink source", async () => {
+      await bestzip.nodeZip({ cwd, source: "top-link.txt", destination });
+      const entries = readZipEntries(destination);
+      assert.equal(entries["top-link.txt"].type, S_IFREG);
+      assert.equal(entries["top-link.txt"].data.toString(), TARGET_CONTENTS);
+    });
+
+    test("recurses into a top-level symlinked directory", async () => {
+      await bestzip.nodeZip({ cwd, source: "vendor-link", destination });
+      const entries = readZipEntries(destination);
+      assert.equal(entries["vendor-link/vendored.txt"].type, S_IFREG);
+      assert.equal(
+        entries["vendor-link/vendored.txt"].data.toString(),
+        "from vendor dir"
+      );
+    });
+  }
+);


### PR DESCRIPTION
The node implementation's default (followSymLinks unset) differed from the native zip command for top-level symlinks: nodeZip stored an in-directory file symlink as a link because it added walked entries without explicit stats (letting archiver lstat them), while native follows symlinks. 

Fix: Pass stat() stats for every walked entry so archiver dereferences symlinks, so the default now follows symlinks and recurses into symlinked directories — matching nativeZip.

Add tests locking in the reconciled default (file symlink followed, top-level symlink source followed, symlinked directory recursed into).