### PR TITLE
Validate compression level and add level test coverage

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -14,7 +14,6 @@ const argv = yargs(hideBin(process.argv))
   .option("level", {
     describe: "Level of compression",
     type: "number",
-    default: -1,
   })
   .option("follow-sym-links", {
     describe:
@@ -25,11 +24,6 @@ const argv = yargs(hideBin(process.argv))
 
 const destination = argv._.shift();
 const source = argv._;
-
-if (argv.level < -1 || argv.level > 9) {
-  console.error("Invalid compression level, must be >= 0 and <= 9");
-  process.exit(1);
-}
 
 console.log("Writing %s to %s...", source.join(", "), destination);
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -5,7 +5,13 @@ import * as bestzip from "../lib/bestzip.js";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 
-const argv = yargs(hideBin(process.argv))
+// Rewrite -0 … -9 into --level 0 … --level 9 before yargs parses them
+const preprocessed = hideBin(process.argv).flatMap((arg) => {
+  const match = /^-([0-9])$/.exec(arg);
+  return match ? ["--level", match[1]] : [arg];
+});
+
+const argv = yargs(preprocessed)
   .usage("\nUsage: bestzip destination.zip sources/")
   .option("force", {
     describe: "Force use of node.js or native zip methods",

--- a/lib/bestzip.js
+++ b/lib/bestzip.js
@@ -97,11 +97,32 @@ function walkDir(fullPath) {
   return files.reduce((acc, cur) => acc.concat(cur), []);
 }
 
+// Validates the compression level. A level of exactly 0-9 (an integer) is
+// accepted; anything else that is set causes an error. An unset level is
+// allowed and left to each implementation's default.
+function validateLevel(level) {
+  if (typeof level === "undefined") {
+    return;
+  }
+  if (
+    typeof level !== "number" ||
+    !Number.isInteger(level) ||
+    level < 0 ||
+    level > 9
+  ) {
+    const typehint = typeof level === "number" ? "" : ` (${typeof level})`;
+    throw new Error(
+      `bestzip: level should be an integer from 0 to 9, got ${level}${typehint}`
+    );
+  }
+}
+
 const nativeZip = async (options) => {
   const cwd = options.cwd || process.cwd();
   const command = "zip";
   const sources = await expandSources(cwd, options.source);
   const destination = path.resolve(cwd, options.destination);
+  validateLevel(options.level);
   // followSymLinks: false opts into storing symlinks as links; the default
   // (unset or true) follows symlinks and is unchanged.
   const storeLinks = options.followSymLinks === false;
@@ -117,18 +138,13 @@ const nativeZip = async (options) => {
   }
 
   const args = ["--quiet", "--recurse-paths"];
+  if (typeof options.level === "number") {
+    args.push("-" + options.level.toString());
+  }
   if (storeLinks) {
     args.push("--symlinks");
   }
   args.push(destination, "--", ...sources);
-  if (
-    typeof options.level == "number" &&
-    !isNaN(options.level) &&
-    options.level >= 0 &&
-    options.level <= 9
-  ) {
-    args.splice(0, 0, "-" + options.level.toString());
-  }
 
   return new Promise((resolve, reject) => {
     const zipProcess = cp.spawn(command, args, {
@@ -155,6 +171,7 @@ const nativeZip = async (options) => {
 // based on http://stackoverflow.com/questions/15641243/need-to-zip-an-entire-directory-using-node-js/18775083#18775083
 const nodeZip = async (options) => {
   const cwd = options.cwd || process.cwd();
+  validateLevel(options.level);
   // followSymLinks: false stores symlinks as links; the default (unset or
   // true) follows symlinks, matching the native zip implementation.
   const storeLinks = options.followSymLinks === false;

--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,12 @@ package.json:
 }
 ```
 
+## Command line options
+
+* `--level N` / `-N`: Level of compression, as with the native `zip` command. `N` must be an integer from 0 (store, no compression) to 9 (maximum compression). Defaults to each implementation's own default when unset.
+* `--force node|native`: Force the Node.js implementation or the native `zip` command instead of letting bestzip pick automatically.
+* `--follow-sym-links`: Follow symbolic links and include their target contents in the archive (the default). Pass the flag to keep this default; there is no CLI opt-out.
+
 ## Programmatic usage from within Node.js
 
 ```javascript

--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,7 @@ package.json:
 
 * `--level N` / `-N`: Level of compression, as with the native `zip` command. `N` must be an integer from 0 (store, no compression) to 9 (maximum compression). Defaults to each implementation's own default when unset.
 * `--force node|native`: Force the Node.js implementation or the native `zip` command instead of letting bestzip pick automatically.
-* `--follow-sym-links`: Follow symbolic links and include their target contents in the archive (the default). Pass the flag to keep this default; there is no CLI opt-out.
+* `--follow-sym-links` / `--no-follow-sym-links`: Follow symbolic links and include their target contents in the archive (the default). Use `--no-follow-sym-links` to disable this and store symlinks as links instead.
 
 ## Programmatic usage from within Node.js
 

--- a/readme.md
+++ b/readme.md
@@ -65,11 +65,12 @@ await zip({
 // Callbacks also work: zip(destination, sources, callback)
 ```
 
-### Options
+### API Options
 
 * `source`: Path or paths to files and folders to include in the zip file. String or Array of Strings.
 * `destination`: Path to generated .zip file.
 * `cwd`: Set the Current Working Directory that source and destination paths are relative to. Defaults to `process.cwd()`
+* `level`: Level of compression, as with the native `zip` command. An integer from 0 (store, no compression) to 9 (maximum compression). Defaults to each implementation's own default when unset.
 
 ## How to control the directory structure
 

--- a/test/level.test.js
+++ b/test/level.test.js
@@ -78,6 +78,36 @@ describe("compression level", () => {
     );
   });
 
+  test("cli -N shorthand is equivalent to --level N", () => {
+    const withLevel = (level) => {
+      const result = spawnSync(
+        process.execPath,
+        [cli, "--level", String(level), destination, "big.txt"],
+        { cwd, encoding: "utf8" }
+      );
+      assert.equal(result.status, 0, result.stderr);
+      return size();
+    };
+    const withShorthand = (n) => {
+      const result = spawnSync(
+        process.execPath,
+        [cli, `-${n}`, destination, "big.txt"],
+        { cwd, encoding: "utf8" }
+      );
+      assert.equal(result.status, 0, result.stderr);
+      return size();
+    };
+    for (const n of [0, 1, 5, 9]) {
+      const sizeLong = withLevel(n);
+      const sizeShort = withShorthand(n);
+      assert.equal(
+        sizeShort,
+        sizeLong,
+        `-N shorthand: -${n} (${sizeShort} bytes) should equal --level ${n} (${sizeLong} bytes)`
+      );
+    }
+  });
+
   describe("invalid level", () => {
     const invalidLevels = [-1, 10, 1.5, -5, "5", NaN];
 

--- a/test/level.test.js
+++ b/test/level.test.js
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { after, beforeEach, describe, test } from "node:test";
+
+import * as bestzip from "../lib/bestzip.js";
+import { init } from "./helpers.js";
+
+const { tmpdir, cleanup } = init("compression-level");
+const cwd = path.join(tmpdir, "cwd");
+const compressibleFile = path.join(cwd, "big.txt");
+const destination = path.join(cwd, "out.zip");
+const cli = path.join(import.meta.dirname, "../bin/cli.js");
+
+// Highly-compressible content so level 0 (stored) is dramatically larger than
+// level 9 (deflated), making the assertions robust across platforms.
+const COMPRESSIBLE = "hello world hello world ".repeat(5000);
+
+const size = () => fs.statSync(destination).size;
+
+const kb = (bytes) => `${(bytes / 1024).toFixed(1)} kB`;
+
+// Zip the same compressible file at level 0 and level 9 and assert the
+// resulting archives differ by a large margin, i.e. the level was honored.
+async function assertLevelHonored(impl, label) {
+  await impl({ cwd, source: "big.txt", destination, level: 0 });
+  const size0 = size();
+  await impl({ cwd, source: "big.txt", destination, level: 9 });
+  const size9 = size();
+  assert.ok(
+    size0 > size9 * 5,
+    `${label}: level 0 (${kb(size0)}) should be much larger than level 9 (${kb(
+      size9
+    )})`
+  );
+}
+
+describe("compression level", () => {
+  const hasNative = bestzip.hasNativeZip();
+
+  beforeEach(() => {
+    fs.rmSync(tmpdir, { recursive: true, force: true });
+    fs.mkdirSync(cwd, { recursive: true });
+    fs.writeFileSync(compressibleFile, COMPRESSIBLE);
+  });
+  after(() => cleanup());
+
+  test("nodeZip honors the level", async () => {
+    await assertLevelHonored(bestzip.nodeZip, "nodeZip");
+  });
+
+  test("nativeZip honors the level", { skip: !hasNative }, async () => {
+    await assertLevelHonored(bestzip.nativeZip, "nativeZip");
+  });
+
+  test("bestzip() forwards the level to the selected implementation", async () => {
+    await assertLevelHonored((o) => bestzip.zip(o), "bestzip()");
+  });
+
+  test("cli --level is honored", () => {
+    const run = (level) => {
+      const result = spawnSync(
+        process.execPath,
+        [cli, "--level", String(level), destination, "big.txt"],
+        { cwd, encoding: "utf8" }
+      );
+      assert.equal(result.status, 0, result.stderr);
+      return size();
+    };
+    const size0 = run(0);
+    const size9 = run(9);
+    assert.ok(
+      size0 > size9 * 5,
+      `cli --level: level 0 (${kb(
+        size0
+      )}) should be much larger than level 9 (${kb(size9)})`
+    );
+  });
+
+  describe("invalid level", () => {
+    const invalidLevels = [-1, 10, 1.5, -5, "5", NaN];
+
+    function expectedError(level) {
+      const typehint = typeof level === "number" ? "" : ` (${typeof level})`;
+      return new RegExp(
+        `bestzip: level should be an integer from 0 to 9, got ${level}${typehint.replace(
+          /[.*+?^${}()|[\]\\]/g,
+          "\\$&"
+        )}`
+      );
+    }
+
+    async function assertThrows(impl) {
+      for (const level of invalidLevels) {
+        await assert.rejects(
+          impl({ cwd, source: "big.txt", destination, level }),
+          expectedError(level)
+        );
+      }
+    }
+
+    test("nodeZip throws", async () => {
+      await assertThrows(bestzip.nodeZip);
+    });
+
+    test("nativeZip throws", { skip: !hasNative }, async () => {
+      await assertThrows(bestzip.nativeZip);
+    });
+  });
+});


### PR DESCRIPTION
Add a validateLevel() check used by both nodeZip and nativeZip: a level must be an integer from 0 to 9 when set (unset is allowed). Invalid levels reject with a clear message including the offending type when it's not a number.

The CLI no longer defaults level to -1 or validates it itself; it passes through undefined and lets the library validate. nativeZip now appends the level with push() next to the other native flags.

Add test/level.test.js covering that nodeZip, nativeZip (when present), bestzip(), and the CLI all honor the level, and that invalid levels reject.