### PR TITLE
Warn that follow symlink default will change in next major release

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -49,6 +49,7 @@ zip({
   verbose: !!argv.verbose,
   level: argv.level,
   followSymLinks: argv.followSymLinks,
+  viaCli: true,
 })
   .then(function () {
     console.log("zipped!");

--- a/lib/bestzip.js
+++ b/lib/bestzip.js
@@ -117,6 +117,56 @@ function validateLevel(level) {
   }
 }
 
+function detectSymlinks(cwd, sources) {
+  const symlinks = [];
+  for (const source of sources) {
+    const fullPath = path.resolve(cwd, source);
+    let stats;
+    try {
+      stats = fs.lstatSync(fullPath);
+    } catch (e) {
+      continue;
+    }
+    if (stats.isSymbolicLink()) {
+      symlinks.push(fullPath);
+    } else if (stats.isDirectory()) {
+      const entries = walkDir(fullPath);
+      for (const entry of entries) {
+        const entryStats = fs.lstatSync(entry);
+        if (entryStats.isSymbolicLink()) {
+          symlinks.push(entry);
+        }
+      }
+    }
+  }
+  return symlinks;
+}
+
+function maybeWarnAboutSymlinks(options, symlinks, cwd) {
+  if (options.followSymLinks !== undefined || symlinks.length === 0) {
+    return;
+  }
+  const cli = options.viaCli;
+  const optIn = cli ? "pass --follow-sym-links" : "set followSymLinks: true";
+  const optOut = cli
+    ? "pass --no-follow-sym-links"
+    : "set followSymLinks: false";
+  let lines = symlinks.map((p) => path.relative(cwd, p));
+  if (lines.length > 4) {
+    lines = lines.slice(0, 3);
+    lines.push(`...and ${symlinks.length - 3} more`);
+  }
+  console.warn(
+    "Warning: Symbolic links are followed by default — their target contents are included in the archive.\n" +
+      `To keep this behavior and prevent this warning, ${optIn}.\n` +
+      `To store symlinks as links instead, ${optOut}.\n` +
+      "This default will change in v4 to store symlinks as links. " +
+      "Set followSymLinks explicitly to opt in to following.\n" +
+      "Detected symlinks:\n" +
+      lines.join("\n")
+  );
+}
+
 const nativeZip = async (options) => {
   const cwd = options.cwd || process.cwd();
   const command = "zip";
@@ -135,6 +185,11 @@ const nativeZip = async (options) => {
     throw new Error(
       "The native zip command on this platform cannot store symlinks as links. Use the bestzip() entry point, which will select the node implementation, or set followSymLinks to true to follow symlinks instead."
     );
+  }
+
+  if (options.followSymLinks === undefined) {
+    const symlinks = detectSymlinks(cwd, sources);
+    maybeWarnAboutSymlinks(options, symlinks, cwd);
   }
 
   const args = ["--quiet", "--recurse-paths"];
@@ -175,6 +230,7 @@ const nodeZip = async (options) => {
   // followSymLinks: false stores symlinks as links; the default (unset or
   // true) follows symlinks, matching the native zip implementation.
   const storeLinks = options.followSymLinks === false;
+  const symlinks = [];
   const output = fs.createWriteStream(path.resolve(cwd, options.destination));
   const archive = new ZipArchive({
     zlib: { level: options.level },
@@ -218,6 +274,7 @@ const nodeZip = async (options) => {
     if (storeLinks) {
       const lstats = await fs.promises.lstat(fullPath);
       if (lstats.isSymbolicLink()) {
+        symlinks.push(fullPath);
         archive.symlink(
           destPath,
           await fs.promises.readlink(fullPath),
@@ -229,6 +286,7 @@ const nodeZip = async (options) => {
         for (const { path: p, stats } of walkDirNoFollow(fullPath)) {
           const subPath = p.substring(fullPath.length);
           if (stats.isSymbolicLink()) {
+            symlinks.push(p);
             archive.symlink(
               destPath + subPath,
               await fs.promises.readlink(p),
@@ -247,11 +305,25 @@ const nodeZip = async (options) => {
     }
 
     const stats = await fs.promises.stat(fullPath);
+    // Detect top-level symlink sources for the warning even when following them.
+    if (options.followSymLinks === undefined) {
+      const lstats = await fs.promises.lstat(fullPath);
+      if (lstats.isSymbolicLink()) {
+        symlinks.push(fullPath);
+      }
+    }
     if (stats.isDirectory()) {
       // Walk directory. Works on directories and directory symlinks.
       const files = walkDir(fullPath);
       for (const f of files) {
         const subPath = f.substring(fullPath.length);
+        // Detect symlinks for the warning even when following them.
+        if (options.followSymLinks === undefined) {
+          const lstats = fs.lstatSync(f);
+          if (lstats.isSymbolicLink()) {
+            symlinks.push(f);
+          }
+        }
         // Pass explicit (stat) stats so archiver dereferences symlinks and
         // stores their target contents rather than the link itself. This makes
         // the default behavior match the native zip implementation, which
@@ -272,6 +344,7 @@ const nodeZip = async (options) => {
     for (const source of expandedSources) {
       await addSource(source);
     }
+    maybeWarnAboutSymlinks(options, symlinks, cwd);
     archive.finalize();
   } catch (err) {
     rejectPromise(err);

--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,7 @@ package.json:
     //...
     "scripts": {
         "build" "...",
-        "zip": "bestzip bundle.zip build/*",
+        "zip": "bestzip --no-follow-sym-links bundle.zip build/*",
         "upload": "....",
         "deploy": "npm run build && npm run zip && npm run upload"
     }
@@ -51,14 +51,16 @@ import zip from 'bestzip';
 // zip a single source
 await zip({
   source: 'build/*',
-  destination: './destination.zip'
+  destination: './destination.zip',
+  followSymLinks: false,
 })
 
 // zip multiple sources, starting in a different CWD (current working directory)
 await zip({
   source: ['img1.jpg', 'img2.jpg', 'imgn.jpg'],
   destination: '../images.zip',
-  cwd: './images/' // optional, defaults to process.cwd()
+  cwd: './images/', // optional, defaults to process.cwd()
+  followSymLinks: false,
 })
 
 // Promises also work: zip({source, destination}).then(...).catch(...)
@@ -71,6 +73,17 @@ await zip({
 * `destination`: Path to generated .zip file.
 * `cwd`: Set the Current Working Directory that source and destination paths are relative to. Defaults to `process.cwd()`
 * `level`: Level of compression, as with the native `zip` command. An integer from 0 (store, no compression) to 9 (maximum compression). Defaults to each implementation's own default when unset.
+* `followSymLinks`: Follow symbolic links and include the contents of their targets in the zip file. When set to `true` or `false` the preference is honored and no warning is printed. When left unset, symbolic links are followed (the current default) and a warning is printed whenever symlinks are detected, because this default will change in v4 to store symlinks as links instead (see [Symbolic links](#symbolic-links)).
+
+## Symbolic links
+
+By default, bestzip **follows** symbolic links — their target contents are included in the archive. When symlinks are present and the `followSymLinks` option has not been set explicitly, bestzip prints a warning to stderr listing the symlinked paths and how to opt in or out.
+
+**This default will change in v4** to store symlinks as link entries (not following them), which is the more secure behavior. To prepare for this, set `followSymLinks` explicitly in your code.
+
+To follow symlinks (the current default), set `followSymLinks: true` (programmatic API) or pass `--follow-sym-links` on the command line. To suppress the warning while keeping the current default, set `followSymLinks: true` explicitly. To store symlinks as links instead, set `followSymLinks: false` or pass `--no-follow-sym-links` on the command line.
+
+When storing symlinks as links, bestzip uses the native `zip` command when available. Some native `zip` builds (notably the Windows build of Info-ZIP) cannot store symlinks as link entries at all, so bestzip falls back to its built-in Node.js implementation in that case. Note that calling `bestzip.nativeZip` directly with `followSymLinks` unset/false on such a platform throws an error; use the `bestzip()` entry point, which routes to the Node.js implementation automatically. Use `bestzip.nativeZipSupportsSymlinks()` to check whether the available native `zip` can store symlinks as links; it returns `true`/`false` and caches its result after the first call. `bestzip.hasNativeZip()` checks whether a native `zip` is installed at all.
 
 ## How to control the directory structure
 

--- a/test/command_injection.test.js
+++ b/test/command_injection.test.js
@@ -6,6 +6,12 @@ import { init } from "./helpers.js";
 
 describe("command injection", () => {
   const hasNativeZip = bestzip.hasNativeZip();
+  // These destination-as-flag vectors only make sense against the native zip
+  // command. When the platform's native zip can't store symlinks, bestzip.zip()
+  // routes to nodeZip, which doesn't use "--" but instead may try to open the
+  // destination path asynchronously (e.g. C:\x) and fail outside the test's
+  // try/catch, breaking the suite.
+  const nativeUsable = hasNativeZip && bestzip.nativeZipSupportsSymlinks();
 
   const { destination, fixturesDir: cwd, reset, cleanup } = init(
     "command_injection",
@@ -57,6 +63,7 @@ describe("command injection", () => {
         "mkdir -p injection",
       ],
       destination: "\\x",
+      flagVector: true,
     },
     {
       source: [
@@ -67,6 +74,7 @@ describe("command injection", () => {
         "mkdir -p injection",
       ],
       destination: "/x",
+      flagVector: true,
     },
   ];
 
@@ -75,7 +83,7 @@ describe("command injection", () => {
       `should NOT execute commands from the list of sources: ${JSON.stringify(
         testCase
       )}`,
-      { skip: !hasNativeZip },
+      { skip: !hasNativeZip || (testCase.flagVector && !nativeUsable) },
       async () => {
         const args = { cwd, destination, ...testCase };
         try {

--- a/test/file_structure.test.js
+++ b/test/file_structure.test.js
@@ -4,7 +4,7 @@ import path from "node:path";
 import assert from "node:assert";
 import { describe, test, before, beforeEach, after } from "node:test";
 import klaw from "klaw-sync";
-import { init } from "./helpers.js";
+import { init, canCreateSymlinks } from "./helpers.js";
 
 const { tmpdir, destination, reset, cleanup } = init("file_structure");
 const __dirname = import.meta.dirname;
@@ -14,6 +14,8 @@ import unzip from "./unzip.js";
 import * as bestzip from "../lib/bestzip.js";
 
 const cli = path.join(__dirname, "../bin/cli.js");
+
+const symlinksAvailable = canCreateSymlinks();
 
 const testCases = [
   { cwd: "test/fixtures/", source: "*" }, // no .dotfiles
@@ -32,6 +34,22 @@ const testCases = [
   { cwd: "test/fixtures", source: "file.txt" },
 ];
 
+// Test cases whose expected output includes symlink entries; they only run when
+// symlinks can actually be created on the host.
+const symlinkKey = (source, cwd) => JSON.stringify({ cwd, source });
+const symlinkDependent = new Set(
+  [
+    { source: "*", cwd: "test/fixtures/" },
+    { source: "./", cwd: "test/fixtures/" },
+    { source: "fixtures/*", cwd: "test/" },
+    { source: "fixtures/", cwd: "test/" },
+    { source: "fixtures/*/*.txt", cwd: "test/" },
+    { source: "file-symlink.txt", cwd: "test/fixtures/" },
+  ].map(({ source, cwd }) => symlinkKey(source, cwd))
+);
+const isSymlinkDependent = (source, cwd) =>
+  symlinkDependent.has(symlinkKey(source, cwd));
+
 const getStructure = (tmpdir) => {
   // strip the tmp dir and convert to unix-style file paths on windows
   return klaw(tmpdir).map(({ path }) =>
@@ -40,21 +58,41 @@ const getStructure = (tmpdir) => {
 };
 
 const createSymlink = () => {
+  if (!symlinksAvailable) {
+    return;
+  }
   if (!fs.existsSync(path.resolve("test/fixtures/subdir-symlink"))) {
-    fs.symlinkSync(
-      path.resolve("test/fixtures/subdir/"),
-      path.resolve("test/fixtures/subdir-symlink"),
-      "dir"
-    );
+    try {
+      fs.symlinkSync(
+        path.resolve("test/fixtures/subdir/"),
+        path.resolve("test/fixtures/subdir-symlink"),
+        "dir"
+      );
+    } catch (e) {
+      if (e.code !== "EEXIST") {
+        throw e;
+      }
+    }
   }
   if (!fs.existsSync(path.resolve("test/fixtures/file-symlink.txt"))) {
-    fs.symlinkSync(
-      path.resolve("test/fixtures/file.txt"),
-      path.resolve("test/fixtures/file-symlink.txt"),
-      "file"
-    );
+    try {
+      fs.symlinkSync(
+        path.resolve("test/fixtures/file.txt"),
+        path.resolve("test/fixtures/file-symlink.txt"),
+        "file"
+      );
+    } catch (e) {
+      if (e.code !== "EEXIST") {
+        throw e;
+      }
+    }
   }
 };
+
+const symlinkOpts = (testCase) =>
+  isSymlinkDependent(testCase.source, testCase.cwd) && !symlinksAvailable
+    ? { skip: true }
+    : undefined;
 
 describe("file structure", () => {
   const hasNativeZip = bestzip.hasNativeZip();
@@ -67,113 +105,137 @@ describe("file structure", () => {
   // so, it's run once for bestzip against the snapshot
   // and, if bestzip used
   for (const testCase of testCases) {
-    test(`cli: ${JSON.stringify(testCase)}`, async (t) => {
-      const sourceArgs =
-        typeof testCase.source === "string"
-          ? testCase.source
-          : testCase.source.join(" ");
+    test(
+      `cli: ${JSON.stringify(testCase)}`,
+      symlinkOpts(testCase),
+      async (t) => {
+        const sourceArgs =
+          typeof testCase.source === "string"
+            ? testCase.source
+            : testCase.source.join(" ");
 
-      child_process.execSync(`node ${cli} ${destination} ${sourceArgs}`, {
-        cwd: path.join(__dirname, "../", testCase.cwd),
-      });
+        child_process.execSync(`node ${cli} ${destination} ${sourceArgs}`, {
+          cwd: path.join(__dirname, "../", testCase.cwd),
+        });
 
-      await unzip(destination, tmpdir);
-      const structure = getStructure(tmpdir);
+        await unzip(destination, tmpdir);
+        const structure = getStructure(tmpdir);
 
-      t.assert.snapshot(structure);
+        t.assert.snapshot(structure);
 
-      // because multiple tests aren't allowed to match the same snapshot,
-      // but we do want to ensure that they all create the same output
-      testCase.structure = structure;
-    });
+        // because multiple tests aren't allowed to match the same snapshot,
+        // but we do want to ensure that they all create the same output
+        testCase.structure = structure;
+      }
+    );
   }
 
   for (const testCase of testCases) {
-    test(`cli with --force=node: ${JSON.stringify(testCase)}`, async (t) => {
-      const sourceArgs =
-        typeof testCase.source === "string"
-          ? testCase.source
-          : testCase.source.join(" ");
+    test(
+      `cli with --force=node: ${JSON.stringify(testCase)}`,
+      symlinkOpts(testCase),
+      async (t) => {
+        const sourceArgs =
+          typeof testCase.source === "string"
+            ? testCase.source
+            : testCase.source.join(" ");
 
-      child_process.execSync(
-        `node ${cli} --force=node ${destination} ${sourceArgs}`,
-        { cwd: path.join(__dirname, "../", testCase.cwd) }
-      );
+        child_process.execSync(
+          `node ${cli} --force=node ${destination} ${sourceArgs}`,
+          { cwd: path.join(__dirname, "../", testCase.cwd) }
+        );
 
-      await unzip(destination, tmpdir);
-      const structure = getStructure(tmpdir);
+        await unzip(destination, tmpdir);
+        const structure = getStructure(tmpdir);
 
-      t.assert.snapshot(structure);
+        t.assert.snapshot(structure);
 
-      // on systems *with* a native zip, this validates that both methods output the same thing (mac, linux)
-      if (testCase.structure) {
-        assert.deepEqual(structure, testCase.structure);
-      } else {
-        // the structure is defined in the first test run, so it may not be defined when running subsets of tests
-        console.log("skipping structure match");
+        // on systems *with* a native zip, this validates that both methods output the same thing (mac, linux)
+        if (testCase.structure) {
+          assert.deepEqual(structure, testCase.structure);
+        } else {
+          // the structure is defined in the first test run, so it may not be defined when running subsets of tests
+          console.log("skipping structure match");
+        }
       }
-    });
+    );
   }
 
   for (const testCase of testCases) {
-    test(`programmatic: ${JSON.stringify(testCase)}`, async (t) => {
-      await bestzip.zip(
-        Object.assign(
-          { destination, cwd: path.join(__dirname, "../", testCase.cwd) },
-          testCase
-        )
-      );
-      await unzip(destination, tmpdir);
-      const structure = getStructure(tmpdir);
+    test(
+      `programmatic: ${JSON.stringify(testCase)}`,
+      symlinkOpts(testCase),
+      async (t) => {
+        await bestzip.zip(
+          Object.assign(
+            { destination, cwd: path.join(__dirname, "../", testCase.cwd) },
+            testCase
+          )
+        );
+        await unzip(destination, tmpdir);
+        const structure = getStructure(tmpdir);
 
-      t.assert.snapshot(structure);
+        t.assert.snapshot(structure);
 
-      if (testCase.structure) {
-        assert.deepEqual(structure, testCase.structure);
-      } else {
-        // the structure is defined in the first test run, so it may not be defined when running subsets of tests
-        console.log("skipping structure match");
+        if (testCase.structure) {
+          assert.deepEqual(structure, testCase.structure);
+        } else {
+          // the structure is defined in the first test run, so it may not be defined when running subsets of tests
+          console.log("skipping structure match");
+        }
       }
-    });
+    );
   }
 
   for (const testCase of testCases) {
-    test(`programmatic with nodeZip: ${JSON.stringify(
-      testCase
-    )}`, async (t) => {
-      await bestzip.nodeZip(
-        Object.assign(
-          { destination, cwd: path.join(__dirname, "../", testCase.cwd) },
-          testCase
-        )
-      );
-      await unzip(destination, tmpdir);
-      const structure = getStructure(tmpdir);
+    test(
+      `programmatic with nodeZip: ${JSON.stringify(testCase)}`,
+      symlinkOpts(testCase),
+      async (t) => {
+        await bestzip.nodeZip(
+          Object.assign(
+            { destination, cwd: path.join(__dirname, "../", testCase.cwd) },
+            testCase
+          )
+        );
+        await unzip(destination, tmpdir);
+        const structure = getStructure(tmpdir);
 
-      t.assert.snapshot(structure);
+        t.assert.snapshot(structure);
 
-      // on systems *with* a native zip, this validates that both methods output the same thing (mac, linux)
-      if (testCase.structure) {
-        assert.deepEqual(structure, testCase.structure);
-      } else {
-        // the structure is defined in the first test run, so it may not be defined when running subsets of tests
-        console.log("skipping structure match");
+        // on systems *with* a native zip, this validates that both methods output the same thing (mac, linux)
+        if (testCase.structure) {
+          assert.deepEqual(structure, testCase.structure);
+        } else {
+          // the structure is defined in the first test run, so it may not be defined when running subsets of tests
+          console.log("skipping structure match");
+        }
       }
-    });
+    );
   }
 
   // we can't use snapshots here, because the absolute paths will change from one system to another
   // but, when native zip is available, we want to compare it to node zip to ensure that the outputs match
-  const absolutePathTestCases = testCases.map((testCase) =>
-    (Array.isArray(testCase.source) ? testCase.source : [testCase.source])
+  const absolutePathTestCases = testCases.map((testCase) => ({
+    args: (Array.isArray(testCase.source) ? testCase.source : [testCase.source])
       .map((arg) => path.join(testCase.cwd, arg))
-      .join(" ")
-  );
+      .join(" "),
+    symlink: isSymlinkDependent(testCase.source, testCase.cwd),
+  }));
 
-  for (const args of absolutePathTestCases) {
+  // The native-vs-node comparison only works when the native zip can actually
+  // participate — it must support --symlinks (or followSymLinks must be set).
+  // On platforms like Windows where Info-ZIP lacks --symlinks, nativeZip will
+  // throw, so skip every case.
+  const nativeUnsupported = !bestzip.nativeZipSupportsSymlinks();
+
+  for (const { args, symlink } of absolutePathTestCases) {
     test(
       `same output between native and node zip with absolute file paths: ${args}`,
-      { skip: !hasNativeZip },
+      {
+        skip:
+          !hasNativeZip || nativeUnsupported || (symlink && !symlinksAvailable),
+      },
       async () => {
         child_process.execSync(
           `node ${cli} --force=node ${destination} ${args}`

--- a/test/symlink_default_behavior.test.js
+++ b/test/symlink_default_behavior.test.js
@@ -63,7 +63,8 @@ describe(
     });
     after(() => fs.rmSync(tmpdir, { recursive: true, force: true }));
 
-    test("follows a file symlink inside a walked directory", async () => {
+    test("follows a file symlink inside a walked directory", async (t) => {
+      const warn = t.mock.method(console, "warn", () => {});
       await bestzip.nodeZip({ cwd, source: "archive-me/", destination });
       const entries = readZipEntries(destination);
       assert.equal(entries["archive-me/link.txt"].type, S_IFREG);
@@ -72,16 +73,26 @@ describe(
         TARGET_CONTENTS
       );
       assert.ok(entries["archive-me/vendor/vendored.txt"]);
+      assert.ok(warn.mock.calls.length > 0);
+      assert.ok(
+        warn.mock.calls
+          .map((c) => c.arguments.join(" "))
+          .join(" ")
+          .includes("Symbolic links are followed by default")
+      );
     });
 
-    test("follows a top-level symlink source", async () => {
+    test("follows a top-level symlink source", async (t) => {
+      const warn = t.mock.method(console, "warn", () => {});
       await bestzip.nodeZip({ cwd, source: "top-link.txt", destination });
       const entries = readZipEntries(destination);
       assert.equal(entries["top-link.txt"].type, S_IFREG);
       assert.equal(entries["top-link.txt"].data.toString(), TARGET_CONTENTS);
+      assert.ok(warn.mock.calls.length > 0);
     });
 
-    test("recurses into a top-level symlinked directory", async () => {
+    test("recurses into a top-level symlinked directory", async (t) => {
+      const warn = t.mock.method(console, "warn", () => {});
       await bestzip.nodeZip({ cwd, source: "vendor-link", destination });
       const entries = readZipEntries(destination);
       assert.equal(entries["vendor-link/vendored.txt"].type, S_IFREG);
@@ -89,6 +100,7 @@ describe(
         entries["vendor-link/vendored.txt"].data.toString(),
         "from vendor dir"
       );
+      assert.ok(warn.mock.calls.length > 0);
     });
   }
 );

--- a/test/symlink_security.test.js
+++ b/test/symlink_security.test.js
@@ -1,0 +1,201 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { after, beforeEach, describe, test } from "node:test";
+
+import * as bestzip from "../lib/bestzip.js";
+import { canCreateSymlinks, init, readZipEntries } from "./helpers.js";
+
+const { tmpdir } = init("symlink_security");
+const cwd = path.join(tmpdir, "cwd");
+const archiveDir = path.join(cwd, "archive-me");
+const secretFile = path.join(tmpdir, "victim-secret.txt");
+const privateDir = path.join(tmpdir, "private");
+const linkToFile = path.join(archiveDir, "leak.txt");
+const linkToDir = path.join(archiveDir, "vendor");
+const normalFile = path.join(archiveDir, "normal.txt");
+const destination = path.join(cwd, "out.zip");
+const cli = path.join(import.meta.dirname, "../bin/cli.js");
+
+const SECRET_CONTENTS = "SECRET=hunter2";
+const CREDS_CONTENTS = "AWS_SECRET=ACCESS";
+
+const S_IFREG = 0o100000;
+const S_IFLNK = 0o120000;
+
+const setup = () => {
+  fs.mkdirSync(archiveDir, { recursive: true });
+  fs.mkdirSync(privateDir, { recursive: true });
+  fs.writeFileSync(secretFile, SECRET_CONTENTS);
+  fs.writeFileSync(path.join(privateDir, "creds.env"), CREDS_CONTENTS);
+  fs.writeFileSync(normalFile, "normal");
+  try {
+    fs.symlinkSync(secretFile, linkToFile);
+  } catch (e) {
+    // already exists
+  }
+  try {
+    fs.symlinkSync(privateDir, linkToDir);
+  } catch (e) {
+    // already exists
+  }
+};
+
+describe("symlink security", { skip: !canCreateSymlinks() }, () => {
+  const runOnBothZips = (title, body) => {
+    test(`${title} (nodeZip)`, async (t) => body(bestzip.nodeZip, t));
+    test(`${title} (nativeZip)`, async (t) => body(bestzip.nativeZip, t));
+  };
+
+  beforeEach(() => {
+    fs.rmSync(tmpdir, { recursive: true, force: true });
+    fs.mkdirSync(cwd, { recursive: true });
+    setup();
+  });
+  after(() => fs.rmSync(tmpdir, { recursive: true, force: true }));
+
+  runOnBothZips(
+    "default follows symlinks and archives their target contents",
+    async (zipMethod) => {
+      await zipMethod({ cwd, source: "archive-me/", destination });
+      const entries = readZipEntries(destination);
+
+      assert.equal(entries["archive-me/leak.txt"].type, S_IFREG);
+      assert.ok(
+        entries["archive-me/leak.txt"].data.toString().includes(SECRET_CONTENTS)
+      );
+      assert.ok(entries["archive-me/vendor/creds.env"]);
+      assert.ok(
+        entries["archive-me/vendor/creds.env"].data
+          .toString()
+          .includes(CREDS_CONTENTS)
+      );
+    }
+  );
+
+  runOnBothZips(
+    "warns the user when symlinks are present and followSymLinks is unset",
+    async (zipMethod, t) => {
+      const warn = t.mock.method(console, "warn", () => {});
+      await zipMethod({ cwd, source: "archive-me/", destination });
+      assert.ok(warn.mock.calls.length > 0);
+      const message = warn.mock.calls
+        .map((c) => c.arguments.join(" "))
+        .join(" ");
+      assert.ok(message.includes("Symbolic links are followed by default"));
+      assert.ok(message.includes("leak.txt"));
+      assert.ok(message.includes("set followSymLinks: true"));
+      assert.ok(message.includes("set followSymLinks: false"));
+      assert.ok(message.includes("v4"));
+    }
+  );
+
+  runOnBothZips(
+    "honors followSymLinks: true and follows symlinks",
+    async (zipMethod) => {
+      await zipMethod({
+        cwd,
+        source: "archive-me/",
+        destination,
+        followSymLinks: true,
+      });
+      const entries = readZipEntries(destination);
+
+      assert.equal(entries["archive-me/leak.txt"].type, S_IFREG);
+      assert.ok(
+        entries["archive-me/leak.txt"].data.toString().includes(SECRET_CONTENTS)
+      );
+      assert.ok(entries["archive-me/vendor/creds.env"]);
+    }
+  );
+
+  runOnBothZips(
+    "suppresses the warning when followSymLinks is explicitly set",
+    async (zipMethod, t) => {
+      const warn = t.mock.method(console, "warn", () => {});
+      await zipMethod({
+        cwd,
+        source: "archive-me/",
+        destination,
+        followSymLinks: true,
+      });
+      assert.equal(warn.mock.callCount(), 0);
+
+      await zipMethod({
+        cwd,
+        source: "archive-me/",
+        destination,
+        followSymLinks: false,
+      });
+      assert.equal(warn.mock.callCount(), 0);
+    }
+  );
+
+  runOnBothZips(
+    "honors followSymLinks: false and stores symlinks as links",
+    async (zipMethod) => {
+      await zipMethod({
+        cwd,
+        source: "archive-me/",
+        destination,
+        followSymLinks: false,
+      });
+      const entries = readZipEntries(destination);
+
+      assert.equal(entries["archive-me/leak.txt"].type, S_IFLNK);
+      assert.equal(entries["archive-me/vendor"].type, S_IFLNK);
+      assert.equal(entries["archive-me/vendor/creds.env"], undefined);
+    }
+  );
+
+  test("cli warns and follows symlinks by default", () => {
+    const result = spawnSync(
+      process.execPath,
+      [cli, destination, "archive-me/"],
+      { cwd, encoding: "utf8" }
+    );
+    assert.ok(result.stderr.includes("Symbolic links are followed by default"));
+    assert.ok(result.stderr.includes("pass --follow-sym-links"));
+    assert.ok(result.stderr.includes("pass --no-follow-sym-links"));
+    const entries = readZipEntries(destination);
+    assert.equal(entries["archive-me/leak.txt"].type, S_IFREG);
+    assert.ok(
+      entries["archive-me/leak.txt"].data.toString().includes(SECRET_CONTENTS)
+    );
+  });
+
+  test("cli --follow-sym-links follows symlinks without warning", () => {
+    const result = spawnSync(
+      process.execPath,
+      [cli, "--follow-sym-links", destination, "archive-me/"],
+      { cwd, encoding: "utf8" }
+    );
+    assert.ok(
+      !result.stderr.includes("Symbolic links are followed by default")
+    );
+    const entries = readZipEntries(destination);
+    assert.equal(entries["archive-me/leak.txt"].type, S_IFREG);
+    assert.ok(
+      entries["archive-me/leak.txt"].data.toString().includes(SECRET_CONTENTS)
+    );
+  });
+
+  test("cli --no-follow-sym-links stores symlinks as links without warning", () => {
+    const result = spawnSync(
+      process.execPath,
+      [cli, "--no-follow-sym-links", destination, "archive-me/"],
+      { cwd, encoding: "utf8" }
+    );
+    assert.ok(
+      !result.stderr.includes("Symbolic links are followed by default")
+    );
+    const entries = readZipEntries(destination);
+    assert.equal(entries["archive-me/leak.txt"].type, S_IFLNK);
+    assert.equal(entries["archive-me/vendor/creds.env"], undefined);
+  });
+
+  test("nativeZipSupportsSymlinks returns a boolean", () => {
+    assert.equal(typeof bestzip.nativeZipSupportsSymlinks(), "boolean");
+  });
+});

--- a/test/symlink_security.test.js
+++ b/test/symlink_security.test.js
@@ -43,9 +43,13 @@ const setup = () => {
 };
 
 describe("symlink security", { skip: !canCreateSymlinks() }, () => {
+  const hasNativeZip = bestzip.hasNativeZip();
+
   const runOnBothZips = (title, body) => {
     test(`${title} (nodeZip)`, async (t) => body(bestzip.nodeZip, t));
-    test(`${title} (nativeZip)`, async (t) => body(bestzip.nativeZip, t));
+    test(`${title} (nativeZip)`, { skip: !hasNativeZip }, async (t) =>
+      body(bestzip.nativeZip, t)
+    );
   };
 
   beforeEach(() => {


### PR DESCRIPTION
When the flag is left to default, scan for symlinks in the sources and log a warning that the behavior will change in the next major version, along with instructions on how to opt in or out of following symlinks